### PR TITLE
Links to PDF documents replaced in contract.xml

### DIFF
--- a/src/main/webapp/content/publish/contract.xml
+++ b/src/main/webapp/content/publish/contract.xml
@@ -48,8 +48,8 @@
     <h3>6. Formulare</h3> 
     <p>
       Die Formulare in denen Sie den hier genannten Vertragsbedingungen schriftlich zustimmen, werden Ihnen im Laufe des Publikationsprozesses automatisch angeboten. <br/>
-      <a href="../epub/Autorenvertrag_2017.pdf">Einverständniserklärung zur Veröffentlichung einer Online-Publikation</a> <br/> 
-      <a href="../diss/formblatt_ediss_2018.pdf">Formblatt für die Abgabe von elektronischen Dissertationen</a>
+      <a href="../epub/UDE-Autorenvertrag_DE.pdf">Vertrag über eine Veröffentlichung auf dem Repositorium DuEPublico</a> <br/> 
+      <a href="../epub/UDE-Autorenvertrag_EN.pdf">Contract for publication in the DuEPublico repository</a>
     </p> 
   </section>  
 </MyCoReWebPage>


### PR DESCRIPTION
Auf der Seite "Rechtliche Vereinbarungen für Veröffentlichungen auf DuEPublico" (https://duepublico2.uni-due.de/content/publish/contract.xml) sind noch die alten Autorenverträge verlinkt. Diese müssen durch die neuen ersetzt werden:
UDE-Autorenvertrag_DE_Formular.pdf
UDE-Autorenvertrag_DE_Formular.pdf