### PR TITLE
Links to PDF document replaced (guidelines.xml)

### DIFF
--- a/src/main/webapp/content/publish/guidelines.xml
+++ b/src/main/webapp/content/publish/guidelines.xml
@@ -44,8 +44,8 @@
   </p>
   <p>
   Die Rechteübertragung bedarf grundsätzlich der Schriftform: <br/> 
-   <a href="../epub/UDE-Autorenvertrag_DE.pdf">Einverständniserklärung zur Veröffentlichung einer Online-Publikation</a> <br/> 
-   <a href="../diss/formblatt_ediss.pdf">Formblatt für die Abgabe von elektronischen Dissertationen</a>
+   <a href="../epub/UDE-Autorenvertrag_DE.pdf">Vertrag über eine Veröffentlichung auf dem Repositorium DuEPublico</a> <br/> 
+      <a href="../epub/UDE-Autorenvertrag_EN.pdf">Contract for publication in the DuEPublico repository</a>
   </p>
   <p>
   Die Einhaltung von Urheber- und Verwertungsrechten Dritter liegt in der Verantwortung der Autor*innen.


### PR DESCRIPTION
Auf der Seite "Leitlinien DuEPublico" (https://duepublico2.uni-due.de/content/publish/guidelines.xml) sind noch die alten Autorenverträge verlinkt. Diese müssen durch die neuen ersetzt werden:
UDE-Autorenvertrag_DE_Formular.pdf
UDE-Autorenvertrag_DE_Formular.pdf