### PR TITLE
Information added to help-text in line 171

### DIFF
--- a/src/main/webapp/editor/editor-customization.xed
+++ b/src/main/webapp/editor/editor-customization.xed
@@ -168,7 +168,7 @@
           </div>
         </div>
         <mir:htmlArea xpath="." label="mir.abstract" placeholder="Zusammenfassung, Abstract"
-          help-text="Zusammenfassung des Inhalts" rows="8" class="required" />
+          help-text="Zusammenfassung des Inhalts. Die Eingabe von Quellcode wie z.B. HTML oder MathML ist bedingt möglich." rows="8" class="required" />
         <xed:validate display="global" required="true">Bitte geben Sie einen Abstract ein.</xed:validate>
       </div>
     </xed:repeat>


### PR DESCRIPTION
Ergänzung der editor-costumization.xed

Help-text ergänzt um Satz "Die Eingabe von Quellcode wie z.B. HTML oder MathML ist bedingt möglich."