### PR TITLE
False link replaced

### DIFF
--- a/src/main/webapp/content/epub/serials.xml
+++ b/src/main/webapp/content/epub/serials.xml
@@ -1182,7 +1182,7 @@ Die redaktionelle Verantwortung jedes Beitrages liegt bei den Autor:innen.</p>
     <div class="card card-default">
       <div class="card-header">
         <h3>
-          <a href="/go/yramedtech">[tsƐt][Ɛl][beː] Magazin</a>
+          <a href="/go/zlb-magazin">[tsƐt][Ɛl][beː] Magazin</a>
         </h3>
       </div>
       <div class="card-body">


### PR DESCRIPTION
Ein Link aus der Übersicht Reihen und Zeitschriften (serials.xml) muss ersetzt werden.