### PR TITLE
Form of e-mail addresses adjusted in all necessary places.

### DIFF
--- a/src/main/resources/xsl/thesis-list-grouped.xsl
+++ b/src/main/resources/xsl/thesis-list-grouped.xsl
@@ -70,7 +70,7 @@
       <p>
         <xsl:value-of select="i18n:translate('thesisList.introCorr')"/>
         <xsl:text> </xsl:text>
-        <a href="mailto:universitaetsbibliographie@ub.uni-due.de">universitaetsbibliographie@ub.uni-due.de</a>.
+        <a href="mailto:universitaetsbibliographie.ub@uni-due.de">universitaetsbibliographie.ub@uni-due.de</a>.
       </p>
     </div>
     <div class="card-footer">

--- a/src/main/webapp/content/brand/contact.xml
+++ b/src/main/webapp/content/brand/contact.xml
@@ -25,14 +25,14 @@
                 <li>
                   Viviane Blaß
                   <br />
-                  <a href="mailto:dissertationen@ub.uni-due.de">dissertationen@ub.uni-due.de</a>
+                  <a href="mailto:dissertationen.ub@uni-due.de">dissertationen.ub@uni-due.de</a>
                   <br />
                   Tel.: 0203 / 379 - 1497
                   <br />
                   <br />
                   Ines Snowley
                   <br />
-                  <a href="mailto:dissertationen@ub.uni-due.de">dissertationen@ub.uni-due.de</a>
+                  <a href="mailto:dissertationen.ub@uni-due.de">dissertationen.ub@uni-due.de</a>
                   <br />
                   Tel.: 0203 / 379 - 2069
                   <br />
@@ -46,7 +46,7 @@
                 <li>
                   Claudia Hinze
                   <br />
-                  <a href="mailto:dissertationen@ub.uni-due.de">dissertationen@ub.uni-due.de</a>
+                  <a href="mailto:dissertationen.ub@uni-due.de">dissertationen.ub@uni-due.de</a>
                   <br />
                   Tel.: 0201 / 183 - 3738
                   <br />
@@ -55,7 +55,7 @@
                 <li>
                   Michaela Greinert
                   <br />
-                  <a href="mailto:dissertationen@ub.uni-due.de">dissertationen@ub.uni-due.de</a>
+                  <a href="mailto:dissertationen.ub@uni-due.de">dissertationen.ub@uni-due.de</a>
                   <br />
                   Tel.: 0201 / 183 - 3738
                   <br />
@@ -64,7 +64,7 @@
                 <li>
                   Bettina Hegemann
                   <br />
-                  <a href="mailto:dissertationen@ub.uni-due.de">dissertationen@ub.uni-due.de</a>
+                  <a href="mailto:dissertationen.ub@uni-due.de">dissertationen.ub@uni-due.de</a>
                   <br />
                   Tel.: 0201 / 183 - 3942
                   <br />
@@ -73,7 +73,7 @@
                 <li>
                   Anne Horstmann
                   <br />
-                  <a href="mailto:dissertationen@ub.uni-due.de">dissertationen@ub.uni-due.de</a>
+                  <a href="mailto:dissertationen.ub@uni-due.de">dissertationen.ub@uni-due.de</a>
                   <br />
                   Tel.: 0201 / 183 - 3849
                 </li>
@@ -85,14 +85,14 @@
                 <li>
                   Britta Bornhuse
                   <br />
-                  <a href="mailto:dissertationen@ub.uni-due.de">dissertationen@ub.uni-due.de</a>
+                  <a href="mailto:dissertationen.ub@uni-due.de">dissertationen.ub@uni-due.de</a>
                   <br />
                   Tel.: 0201 / 723 - 3332
                   <br />
                   <br />
                   Julia Lohe
                   <br />
-                  <a href="mailto:dissertationen@ub.uni-due.de">dissertationen@ub.uni-due.de</a>
+                  <a href="mailto:dissertationen.ub@uni-due.de">dissertationen.ub@uni-due.de</a>
                   <br />
                   Tel.: 0201 / 723 - 3332
                 </li>
@@ -151,7 +151,7 @@
                 <li>
                   Sonja Hendriks
                   <br />
-                  <a href="mailto:duepublico@ub.uni-due.de">duepublico@ub.uni-due.de</a>
+                  <a href="mailto:duepublico.ub@uni-due.de">duepublico.ub@uni-due.de</a>
                   <br />
                   Tel.: 0203 / 379 - 2027
                 </li>
@@ -228,14 +228,14 @@
                 <li>
                   Viviane Blaß
                   <br />
-                  <a href="mailto:dissertationen@ub.uni-due.de">dissertationen@ub.uni-due.de</a>
+                  <a href="mailto:dissertationen.ub@uni-due.de">dissertationen.ub@uni-due.de</a>
                   <br />
                   Phone: 0203 / 379 - 1497
                   <br />
                   <br />
                   Ines Snowley
                   <br />
-                  <a href="mailto:dissertationen@ub.uni-due.de">dissertationen@ub.uni-due.de</a>
+                  <a href="mailto:dissertationen.ub@uni-due.de">dissertationen.ub@uni-due.de</a>
                   <br />
                   Phone: 0203 / 379 - 2069
                 </li>
@@ -247,28 +247,28 @@
                 <li>
                   Claudia Hinze
                   <br />
-                  <a href="mailto:dissertationen@ub.uni-due.de">dissertationen@ub.uni-due.de</a>
+                  <a href="mailto:dissertationen.ub@uni-due.de">dissertationen.ub@uni-due.de</a>
                   <br />
                   Phone: 0201 / 183 - 3738
                 </li>
                 <li>
                   Michaela Greinert
                   <br />
-                  <a href="mailto:dissertationen@ub.uni-due.de">dissertationen@ub.uni-due.de</a>
+                  <a href="mailto:dissertationen.ub@uni-due.de">dissertationen.ub@uni-due.de</a>
                   <br />
                   Phone: 0201 / 183 - 3738
                 </li>
                 <li>
                   Bettina Hegemann
                   <br />
-                  <a href="mailto:dissertationen@ub.uni-due.de">dissertationen@ub.uni-due.de</a>
+                  <a href="mailto:dissertationen.ub@uni-due.de">dissertationen.ub@uni-due.de</a>
                   <br />
                   Phone: 0201 / 183 - 3942
                 </li>
                 <li>
                   Anne Horstmann
                   <br />
-                  <a href="mailto:dissertationen@ub.uni-due.de">dissertationen@ub.uni-due.de</a>
+                  <a href="mailto:dissertationen.ub@uni-due.de">dissertationen.ub@uni-due.de</a>
                   <br />
                   Phone: 0201 / 183 - 3849
                 </li>
@@ -280,14 +280,14 @@
                 <li>
                   Britta Bornhuse
                   <br />
-                  <a href="mailto:dissertationen@ub.uni-due.de">dissertationen@ub.uni-due.de</a>
+                  <a href="mailto:dissertationen.ub@uni-due.de">dissertationen.ub@uni-due.de</a>
                   <br />
                   Phone: 0201 / 723 - 3332
                   <br />
                   <br />
                   Julia Lohe
                   <br />
-                  <a href="mailto:dissertationen@ub.uni-due.de">dissertationen@ub.uni-due.de</a>
+                  <a href="mailto:dissertationen.ub@uni-due.de">dissertationen.ub@uni-due.de</a>
                   <br />
                   Phone: 0201 / 723 - 3332
                 </li>
@@ -344,7 +344,7 @@
                 <li>
                   Sonja Hendriks
                   <br />
-                  <a href="mailto:duepublico@ub.uni-due.de">duepublico@ub.uni-due.de</a>
+                  <a href="mailto:duepublico.ub@uni-due.de">duepublico.ub@uni-due.de</a>
                   <br />
                   Phone: 0203 / 379 - 2027
                 </li>

--- a/src/main/webapp/content/epub/publish.xml
+++ b/src/main/webapp/content/epub/publish.xml
@@ -264,7 +264,7 @@
               DuEPublico <br/>
               Lotharstraße 65, LK <br/>
               47057 Duisburg <br/>
-              <a href="mailto:duepublico@ub.uni-due.de">duepublico@ub.uni-due.de</a>
+              <a href="mailto:duepublico.ub@uni-due.de">duepublico.ub@uni-due.de</a>
               </p>
             </div>
           </li>          


### PR DESCRIPTION
Auf den Seiten contact.xml, publish.xml und thesis-list-grouped.xsl muss die Form der E-Mail-Adressen an die auf den Imperia-Seiten verwendete angepasst werden, Beispiel: "universitaetsbibliographie.ub@uni-due.de" statt wie bisher "universitaetsbibliographie@ub.uni-due.de"