### PR TITLE
oer/publish.xml updated.

### DIFF
--- a/src/main/webapp/content/oer/publish.xml
+++ b/src/main/webapp/content/oer/publish.xml
@@ -33,11 +33,14 @@
           <br />
           <a href="mailto:duepublico.ub@uni-due.de">Katrin Falkenstein-Feldhoff</a>
           (0203 / 37-91504)
-        </p>
+           <br />
+            <a href="mailto:anke.petschenka@uni-due.de">Anke Petschenka</a>
+          (0201 / 183-4548) 
+        </p>        
         <p>
           <i:de>Weitere Informationen zu Open Educational Ressources an der UDE finden Sie auf den
-          <a href="https://learninglab.uni-due.de/projekte/oer-ude">Webseiten der UB</a>!</i:de>
-          <i:en>Further information about Open Educational Resources at the UDE can be found on the <a href="https://learninglab.uni-due.de/projekte/oer-ude">web pages of the<br/> University Library</a>!</i:en>
+          <a href="https://www.uni-due.de/ub/publikationsdienste/oer">Webseiten der UB</a>!</i:de>
+          <i:en>Further information about Open Educational Resources at the UDE can be found on the <a href="https://www.uni-due.de/ub/publikationsdienste/oer">web pages of the<br/> University Library</a>!</i:en>
         </p>
       </div>
     </div>


### PR DESCRIPTION
Der bisherige Link zur OER-UB Seite https://learninglab.uni-due.de/projekte/oer-ude muss ausgetauscht werden durch https://www.uni-due.de/ub/publikationsdienste/oer
Anke Petschenka soll als Ansprechpartnerin ergänzt werden.