### PR TITLE
Change of an annotation field name

### DIFF
--- a/src/main/setup/classifications/noteTypes.xml
+++ b/src/main/setup/classifications/noteTypes.xml
@@ -183,7 +183,7 @@
     <category ID="additional_physical_form">
       <label xml:lang="x-access" text="guest" />
       <label xml:lang="en" text="additional physical form" />
-      <label xml:lang="de" text="Zusätzliche physikalische Formen" />
+      <label xml:lang="de" text="Zusätzliche physische Formen" />
     </category>
     <category ID="action">
       <label xml:lang="de" text="Arbeitsgang" />


### PR DESCRIPTION
Die Bezeichnung des Anmerkungsfeldes "Zusätzliche physikalische Formen" soll in "Zusätzliche physische Formen" geändert werden.