### PR TITLE
Underscore removed from line 145

### DIFF
--- a/src/main/resources/xsl/mycoreobject-infobox.xsl
+++ b/src/main/resources/xsl/mycoreobject-infobox.xsl
@@ -142,7 +142,7 @@
     </fo:block-container>
   </xsl:template>
 
-  <xsl:template match="mods:accessCondition[contains(@xlink:href,'mir_licenses#cc_')]">
+  <xsl:template match="mods:accessCondition[contains(@xlink:href,'mir_licenses#cc')]">
     <xsl:variable name="id" select="substring-after(@xlink:href,'#')" />
     
     <xsl:for-each select="$licenses/mycoreclass//category[@ID=$id]">


### PR DESCRIPTION
Bisher wird die Auswahl der Lizenz CC0 nicht in der Infobox angezeigt.
Damit es passiert, habe ich in Zeile 145 den Unterstrich nach #cc entfernt <xsl:template match="mods:accessCondition[contains(@xlink:href,'mir_licenses#cc')]">.
Bei mir hat es funktioniert. Wenn es anders gemacht werden soll, ändere ich es entsprechend wieder.