### PR TITLE
Style changes: redmine/issues/3446 und 2576

### DIFF
--- a/src/main/webapp/css/duepublico.css
+++ b/src/main/webapp/css/duepublico.css
@@ -4,10 +4,11 @@
 	padding-top: 1rem;
 }
 
-// reduces the font size of the headline on the metadata pages of the publications
+/* reduces the font size of the headline on the metadata pages of the publications */
 #page #main_content .detail_row .main_col h1{
-	font-size:1.5rem;
+	font-size: 1.5rem;
 }
+
 .with-icon {
 	display: flex;
 	flex-direction: row;

--- a/src/main/webapp/css/duepublico.css
+++ b/src/main/webapp/css/duepublico.css
@@ -4,6 +4,10 @@
 	padding-top: 1rem;
 }
 
+// reduces the font size of the headline on the metadata pages of the publications
+#page #main_content .detail_row .main_col h1{
+	font-size:1.5rem;
+}
 .with-icon {
 	display: flex;
 	flex-direction: row;


### PR DESCRIPTION
Die Schriftgröße der Publikationstitel auf den Metadatenseiten wurde reduziert, damit bei sehr langen Titeln nicht fast die gesamte Bildschirmseite eingenommen wird bzw. noch wichtiger: sehr lange Wörter nicht am Ende abgeschnitten und unvollständig angezeigt werden. Betrifft die Tickets #3346 und #2576 in Redmine.