### PR TITLE
Redmine/issue 3882

### DIFF
--- a/src/main/webapp/content/oer/form.xed
+++ b/src/main/webapp/content/oer/form.xed
@@ -243,7 +243,7 @@
                 <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc_by_4.0" />
                 <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc_by-sa_4.0" />
                 <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc_by-nc_4.0" />
-                <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc_by-nc-sa_4.0" />
+                <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc_by-nc-sa_4.0"/>
 
                 <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc0" />
                 <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:gpl_3" />

--- a/src/main/webapp/content/oer/form.xed
+++ b/src/main/webapp/content/oer/form.xed
@@ -242,7 +242,6 @@
 
                 <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc_by_4.0" />
                 <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc_by-sa_4.0" />
-                <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc_by-nd_4.0" />
                 <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc_by-nc_4.0" />
                 <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc_by-nc-sa_4.0" />
 


### PR DESCRIPTION
Fälschlicherweise ist die Lizenzoption CC BY-ND 4.0 im OER-Formular (oer/form.xed) erhalten geblieben. Diese soll aber für OER gar nicht auswählbar sein und wird daher entfernt.