### PR TITLE
Redmine/issue4174

### DIFF
--- a/src/main/webapp/content/epub/serials-closed.xml
+++ b/src/main/webapp/content/epub/serials-closed.xml
@@ -120,23 +120,6 @@
 
 
 
-
-<div class="card card-default">
-      <div class="card-header">
-        <h3>
-          <a href="/go/dmpv">Duisburger Materialien zur Politik- und Verwaltungswissenschaft</a>
-        </h3>
-      </div>
-      <div class="card-body">
-        <p>Hrsg.: Gerhard-Mercator-Universität Duisburg GH <br/>
-		FB 1: Politikwissenschaft <br/>
-		Lotharstr. 65, D-47057 Duisburg</p>
-      </div>
-    </div>
-
-
-
-
  <div class="card card-default">
       <div class="card-header">
         <h3>

--- a/src/main/webapp/content/oer/form.xed
+++ b/src/main/webapp/content/oer/form.xed
@@ -242,7 +242,6 @@
 
                 <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc_by_4.0" />
                 <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc_by-sa_4.0" />
-                <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc_by-nd_4.0" />
                 <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc_by-nc_4.0" />
                 <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc_by-nc-sa_4.0" />
 


### PR DESCRIPTION
Die Reihe "Duisburger Materialien zur Politik- und Verwaltungswissenschaft" muss aus der Übersicht serials-closed.xml entfernt werden, da es keine Informationen zur Reihe gibt und in DuEPublico nur einen Band, der darunter veröffentlicht war.