### PR TITLE
Modification of the form text

### DIFF
--- a/src/main/resources/xfdf-config.xml
+++ b/src/main/resources/xfdf-config.xml
@@ -25,13 +25,13 @@
       <file>content/epub/UDE-Autorenvertrag_DE.pdf</file>
       <original>6A6B4D01CAA48E4FB84741727D8C0FC6</original>
       <modified>7DB6710CAC217142BA722B5C6427E90B</modified>
-      <info>Nicht vergessen: Bitte den Autorenvertrag ausfüllen und einschicken!</info>
+      <info>Nicht vergessen: Bitte den Autorenvertrag ausfüllen und einschicken (gerne per E-Mail)!</info>
     </form>
     <form xml:lang="en">
       <file>content/epub/UDE-Autorenvertrag_EN.pdf</file>
       <original>EE0FD439C9A5AA4EB05EFE690337E707</original>
       <modified>D01FF1B8AE04ED4A9A75198688E91435</modified>
-      <info>Don't forget: Please fill the publication contract and send it to us!</info>
+      <info>Don't forget: Please fill the publication contract and send it to us (preferably via e-mail)!</info>
     </form>
   </collection>
 </xfdf-config>


### PR DESCRIPTION
Da wir es seit einigerzeit bevorzugen Autorenverträge per E-Mail zu erhalten, soll der Hinweistext auf der DuEPublico-Metadatenseite "Nicht vergessen: Bitte den Autorenvertrag ausfüllen und einschicken!" ergänzt werden um "(gerne per E-Mail)".