### PR TITLE
Option 2022 added to select id="year"

### DIFF
--- a/src/main/resources/xsl/thesis-list-grouped.xsl
+++ b/src/main/resources/xsl/thesis-list-grouped.xsl
@@ -81,6 +81,9 @@
           </label>
           <select class="form-control px-2" id="year" name="year">
           <xsl:call-template name="option.year">
+              <xsl:with-param name="year">2022</xsl:with-param>
+            </xsl:call-template>
+          <xsl:call-template name="option.year">
               <xsl:with-param name="year">2021</xsl:with-param>
             </xsl:call-template>
             <xsl:call-template name="option.year">

--- a/src/main/webapp/content/diss/search.xed
+++ b/src/main/webapp/content/diss/search.xed
@@ -21,7 +21,8 @@
                  <div class="form-group">
                    <label for="year" class="pr-2">Promotionsjahr</label>
                    <select name="year" id="year" class="form-control px-2">
-                     <option selected="">2021</option>
+                     <option selected="">2022</option>
+		     <option>2021</option>
                      <option>2020</option>
                      <option>2019</option>
                      <option>2018</option>


### PR DESCRIPTION
Das Auswahlmenü auf der Seite diss/search.xed muss um das Jahr 2022 erweitert werden.