### PR TITLE
Redmine/issue4709

### DIFF
--- a/src/main/resources/actionmappings.xml
+++ b/src/main/resources/actionmappings.xml
@@ -82,7 +82,8 @@
   <collection name="LuL">
     <action action="create">
       <when condition="(group = admin)" url="/editor/editor-admins.xed" />
-      <when condition="true" url="" />
+       <when condition="(group = submitter)" url="/content/lehrmaterial/form.xed" />
+      <when condition="true" url="/authorization/login.xed?url=../servlets/MCRActionMappingServlet/LuL/create" />
     </action>
     <action action="create-child">
       <when condition="(group = admin)" url="/editor/editor-admins.xed" />
@@ -93,7 +94,9 @@
       <when condition="true" url="" />
     </action>
     <action action="update">
+    <when condition="(group = submitter)" url="/content/lehrmaterial/form.xed" />
       <when condition="(group = admin)" url="/servlets/MCRLockServlet?url=/editor/editor-dynamic.xed" />
+       <when condition="(status != published)" url="/content/lehrmaterial/form.xed" />
     </action>
     <action action="update-admin">
       <when condition="(group = admin)" url="/servlets/MCRLockServlet?url=/editor/editor-admins.xed" />

--- a/src/main/resources/actionmappings.xml
+++ b/src/main/resources/actionmappings.xml
@@ -82,7 +82,7 @@
   <collection name="LuL">
     <action action="create">
       <when condition="(group = admin)" url="/editor/editor-admins.xed" />
-       <when condition="(group = submitter)" url="/content/lehrmaterial/form.xed" />
+      <when condition="(group = submitter)" url="/content/lehrmaterial/form.xed" />
       <when condition="true" url="/authorization/login.xed?url=../servlets/MCRActionMappingServlet/LuL/create" />
     </action>
     <action action="create-child">
@@ -94,9 +94,9 @@
       <when condition="true" url="" />
     </action>
     <action action="update">
-    <when condition="(group = submitter)" url="/content/lehrmaterial/form.xed" />
+      <when condition="(group = submitter)" url="/content/lehrmaterial/form.xed" />
       <when condition="(group = admin)" url="/servlets/MCRLockServlet?url=/editor/editor-dynamic.xed" />
-       <when condition="(status != published)" url="/content/lehrmaterial/form.xed" />
+      <when condition="(status != published)" url="/content/lehrmaterial/form.xed" />
     </action>
     <action action="update-admin">
       <when condition="(group = admin)" url="/servlets/MCRLockServlet?url=/editor/editor-admins.xed" />

--- a/src/main/webapp/content/lehrmaterial/form.xed
+++ b/src/main/webapp/content/lehrmaterial/form.xed
@@ -246,7 +246,6 @@
                 <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc0" />
                 <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:gpl_3" />
                 <xed:include uri="xslStyle:items2options:classification:editor:-1:parents:mir_licenses:odc" />
-
               </select>
               <div style="padding:1ex">
                 Hilfe zur <a target="_blank" href="https://www.uni-due.de/ub/publikationsdienste/cc_lizenzen.php">Auswahl einer geeigneten Creative Commons Lizenz</a>

--- a/src/main/webapp/content/lehrmaterial/form.xed
+++ b/src/main/webapp/content/lehrmaterial/form.xed
@@ -1,0 +1,266 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<MyCoReWebPage>
+  <section xml:lang="de" title="Lehrmaterial veröffentlichen" />
+  <section xml:lang="en" title="Publish your teaching material" />
+
+  <section xml:lang="de">
+    <div class="alert alert-info" role="alert">
+      Bitte geben Sie hier die beschreibenden Daten des Lehrmaterials ein.<br/>
+      Pflichtfelder sind mit einem (*) gekennzeichnet.<br/>
+      Durch klicken auf [+] können Sie ein Eingabefeld wiederholen!
+    </div>
+  </section>
+  <section xml:lang="en">
+    <div class="alert alert-info" role="alert">
+      Please, enter the descriptive data of your teaching material here.<br/>
+      Required fields are marked with (*).<br/>
+      You can repeat some fields by clicking the [+] button!
+    </div>
+  </section>
+
+  <section xml:lang="all">
+
+    <xed:form xmlns:xed="http://www.mycore.de/xeditor" xmlns:mir="http://www.mycore.de/mir" method="post" role="form" class="form-horizontal">
+      <xed:cancel url="../../servlets/MCRLockServlet?action=unlock&amp;id={$id}&amp;url=/receive/{$id}?XSL.Status.Message=mir.editstatus.canceled&amp;XSL.Status.Style=danger" />
+      <xed:cancel url="{$cancelUrl}?XSL.Status.Message=mir.editstatus.canceled&amp;XSL.Status.Style=danger" />
+      <xed:cancel url="publish.xml?XSL.Status.Message=mir.editstatus.canceled&amp;XSL.Status.Style=danger" />
+
+      <xed:preload uri="xslStyle:editor/mir2xeditor:webapp:editor/editor-includes.xed" />
+      <xed:preload uri="xslStyle:editor/mir2xeditor:webapp:editor/editor-customization.xed"  />
+      <xed:preload uri="xslStyle:editor/mir2xeditor:webapp:content/lehrmaterial/form.xed" />
+
+      <xed:include ref="in.out" />
+
+      <xed:bind xpath="/mycoreobject">
+        <xed:include ref="mycore.common" />
+
+        <xed:bind xpath="metadata/def.modsContainer[@class='MCRMetaXML'][@notinherit='true']/modsContainer/mods:mods">
+
+          <xed:bind xpath="mods:classification[@authorityURI='https://duepublico.uni-due.de/api/v1/classifications/collection']/@valueURIxEditor" set="OER" />
+
+          <xed:include ref="failed-validation-messages" />
+
+          <xed:include ref="title.main" />
+          <xed:validate xpath="//mods:mods/mods:titleInfo/mods:title" required="true" i18n="mir.validation.title" display="global" />
+
+          <xed:include ref="persons" />
+
+          <xed:include ref="description" />
+
+          <xed:include ref="publication" />
+
+          <xed:include ref="duepublico.cancel.submit" />
+
+          <xed:include ref="cleanup-rules" />
+          <xed:include ref="validation-rules" />
+
+          <xed:include ref="javascript" />
+
+          <!-- frame for modal window -->
+          <xed:include ref="modal.name" />
+          <xed:include ref="modal.body" />
+
+        </xed:bind>
+        <xed:bind xpath="service/servstates[@class='MCRMetaClassification']/servstate[@classid='state']/@categid" initially="submitted" />
+      </xed:bind>
+
+      <xed:template id="title.main">
+        <fieldset>
+          <legend class="mir-fieldset-legend">Titel / Bezeichnung des Lehrmaterials:</legend>
+          <xed:bind xpath="mods:titleInfo">
+            <div class="mir-fieldset-content">
+              <mir:textfield xpath="mods:title" label="mir.title" placeholder="Titel / Bezeichnung des Lehrmaterial"
+                help-text="Haupttitel des Materials" class="required" required="true" required-i18n="mir.validation.title" />
+              <mir:textfield xpath="mods:subTitle" label="mir.title.subTitle" help-text="Untertitel zum Haupttitel des Materials" />
+              <div class="form-group row required">
+                <label class="col-md-3 col-form-label text-right">Sprache des Titels:</label>
+                <div class="col-md-6">
+                  <xed:bind xpath="@xml:lang" initially="de">
+                    <xed:include ref="lang.list" />
+                  </xed:bind>
+                </div>
+                <mir:help-pmud help-text="Sprache des Titels/der Bezeichnung des Materials (nicht zwingend identisch mit der Sprache, in der das Lehrmaterial selbst verfasst ist)" />
+              </div>
+            </div>
+          </xed:bind>
+        </fieldset>
+      </xed:template>
+
+      <xed:template id="title.translated">
+        <fieldset>
+          <legend class="mir-fieldset-legend">Titel der Publikation (in englischer Übersetzung, falls Originaltitel nicht englisch):
+          </legend>
+          <xed:bind xpath="mods:titleInfo[2]">
+            <div class="mir-fieldset-content">
+              <mir:textfield xpath="mods:title" label="mir.title"
+                placeholder="Titel der Publikation (in englischer Übersetzung)"
+                help-text="Übersetzter Haupttitel der Publikation (falls Originaltitel nicht englisch)" />
+              <mir:textfield xpath="mods:subTitle" label="mir.title.subTitle"
+                help-text="Übersetzter Untertitel der Publikation" />
+              <xed:bind xpath="@xml:lang" default="en" />
+              <xed:bind xpath="@type" default="translated" />
+            </div>
+          </xed:bind>
+        </fieldset>
+      </xed:template>
+
+      <xed:template id="persons">
+        <fieldset>
+          <legend class="mir-fieldset-legend">AutorInnen und weitere beitragende Personen:</legend>
+          <div class="mir-fieldset-content">
+            <xed:include ref="name.repeated" />
+            <xed:include ref="duepublico.institute" />
+          </div>
+        </fieldset>
+      </xed:template>
+
+      <xed:template id="description">
+        <fieldset>
+          <legend class="mir-fieldset-legend">Inhaltliche Angaben:</legend>
+          <div class="mir-fieldset-content">
+            <xed:include ref="genre.oer" />
+
+            <xed:bind xpath="mods:typeOfResource/@mcr:categId" initially="typeOfResource:text"/>
+            <xed:include ref="type.of.resource.repeated" />
+
+            <xed:include ref="extent" />
+            <xed:include ref="duepublico.language" />
+            <xed:include ref="destatis" />
+            <xed:include ref="podcast" />
+            <xed:bind xpath="mods:classification[@authorityURI='https://duepublico.uni-due.de/api/v1/classifications/destatis']/@valueURIxEditor">
+              <xed:validate required="true" i18n="mir.validation.oer" display="global" />
+            </xed:bind>
+
+            <xed:choose>
+              <xed:when test="xed:call-java('org.mycore.common.xml.MCRXMLFunctions','isCurrentUserInRole','admin')">
+                <xed:include ref="subject.complex" />
+              </xed:when>
+              <xed:otherwise>
+                <xed:include ref="subject.simple" />
+              </xed:otherwise>
+            </xed:choose>
+          </div>
+          <xed:include ref="link.repeated" />
+          <xed:include ref="date.issued.datetimepicker" />
+
+          <xed:include ref="oer.description" />
+          <xed:include ref="comment" />
+        </fieldset>
+      </xed:template>
+
+      <xed:template id="publication">
+        <fieldset>
+          <legend class="mir-fieldset-legend">Angaben zur Veröffentlichung auf DuEPublico:</legend>
+          <xed:choose>
+            <xed:when
+              test="xed:call-java('org.mycore.common.xml.MCRXMLFunctions','isCurrentUserInRole','admin')">
+              <div class="mir-fieldset-content">
+                <xed:include ref="rights" />
+                <xed:include ref="duepublico.status" />
+                <xed:include ref="embargo.datetimepicker" />
+                <xed:include ref="date.issued.datetimepicker" />
+              </div>
+            </xed:when>
+            <xed:otherwise>
+              <div class="mir-fieldset-content">
+                <xed:include ref="oer.license" />
+              </div>
+              <div class="mir-fieldset-content">
+                <xed:include ref="duepublico.i.agree" />
+              </div>
+            </xed:otherwise>
+          </xed:choose>
+        </fieldset>
+      </xed:template>
+
+    <!-- ================== Genre ============= -->
+
+    <xed:template id="genre.oer">
+      <xed:load-resource name="mir_genres" uri="classification:metadata:-1:children:mir_genres" />
+      <xed:bind xpath="mods:genre[@type='intern'][@authorityURI=$mir_genres/label[@xml:lang='x-uri']/@text]/@valueURIxEditor" initially="{$genre}">
+        <div class="form-group row required {$xed-validation-marker}">
+          <label class="col-md-3 col-form-label text-right">
+            <xed:output i18n="component.mods.genre" />
+          </label>
+          <div class="col-md-6">
+            <div class="controls">
+              <select class="form-control form-control-inline">
+                <option value="">
+                  <xed:output i18n="mir.select" />
+                </option>
+                <xed:include uri="xslStyle:items2options:classification:editor:-1:children:mir_genres:teaching_material" />
+                <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_genres:poster" />
+                <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_genres:audio" />
+                <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_genres:video" />
+                <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_genres:lecture" />
+                <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_genres:other" />
+              </select>
+            </div>
+          </div>
+          <mir:help-pmud help-text="{i18n:mir.help.genre}" />
+        </div>
+      </xed:bind>
+    </xed:template>
+
+    <!-- ================== Beschreibung ============= -->
+
+     <xed:template id="oer.description">
+       <xed:bind xpath="mods:abstract">
+        <div class="form-group row">
+          <label class="col-md-3 col-form-label text-right">Beschreibung des Inhalts:</label>
+          <div class="col-md-6">
+            <textarea class="form-control" placeholder="Beschreibung, Zusammenfassung etc." rows="8" />
+          </div>
+          <div class="col-md-3">
+            <a class="btn btn-secondary info-button" role="button" tabindex="0"
+               data-content="Beschreibung des Lehrmaterials, Zusammenfassung des Inhalts"
+               data-placement="right" data-toggle="popover"><i class="fas fa-info"></i></a>
+          </div>
+        </div>
+      </xed:bind>
+    </xed:template>
+
+      <!-- ================== Lizenz ============= -->
+
+      <xed:template id="oer.license">
+        <xed:bind xpath="mods:accessCondition[@type='use and reproduction']">
+          <div class="form-group row required {$xed-validation-marker}">
+            <label class="col-md-3 col-form-label text-right">
+              <xed:output i18n="mir.rights" />:
+            </label>
+            <div class="col-md-6">
+              <div style="padding:1ex">
+               Sie können Ihr Werk optional unter einer <a href="https://meta.wikimedia.org/wiki/Open_Content_-_A_Practical_Guide_to_Using_Creative_Commons_Licences/Guide/de">Open Content Lizenz</a>
+               veröffentlichen: 
+              </div>
+              <select class="form-control form-control-inline">
+                <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:rights_reserved" />
+                <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc_by_4.0" />
+                <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc_by-sa_4.0" />
+                <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc_by-nd_4.0" />
+                <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc_by-nc_4.0" />
+                <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc_by-nc-sa_4.0" />
+                <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc_by-nc-nd_4.0" />
+
+                <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:cc0" />
+                <xed:include uri="xslStyle:items2options:classification:editor:0:parents:mir_licenses:gpl_3" />
+                <xed:include uri="xslStyle:items2options:classification:editor:-1:parents:mir_licenses:odc" />
+
+              </select>
+              <div style="padding:1ex">
+                Hilfe zur <a target="_blank" href="https://www.uni-due.de/ub/publikationsdienste/cc_lizenzen.php">Auswahl einer geeigneten Creative Commons Lizenz</a>
+              </div>
+              <div style="padding:1ex">
+                Den HTML-Code brauchen Sie nicht zu kopieren, es genügt die Auswahl aus obiger Liste.
+                Lizenzangaben sollten möglichst immer auch in den Dateien selbst (z.B. im PDF) angegeben werden.
+              </div>
+            </div>
+          </div>
+        </xed:bind>
+      </xed:template>
+
+    </xed:form>
+
+  </section>
+</MyCoReWebPage>

--- a/src/main/webapp/content/lehrmaterial/publish.xml
+++ b/src/main/webapp/content/lehrmaterial/publish.xml
@@ -8,93 +8,109 @@
       <i class="fas fa-chalkboard-teacher mr-2" aria-hidden="true" />
       <i:de>Sie möchten Ihre Lehrmaterialien veröffentlichen? - Wir helfen Ihnen!</i:de>
     </h2>
-    
-<div class="card-deck mt-3 mb-3">
-    <div class="card card-default">
-      <h3 class="card-header">
-        <i class="fas fa-file-alt mr-2" aria-hidden="true" />
-       Lehrmaterial als Open Educational Resource (OER) veröffentlichen
-      </h3>
-      <div class="card-body">
-       <p><img class="float: none" src="../../images/OER_Grafik.png" /></p>
-        <p>
-          <i:de>
-          Open Educational Resources (OER) sind selbsterstellte Bildungs- bzw. Lehrmaterialien, 
-          die unter einer freien Lizenz (i. d. R. Creative Commons-Lizenz) stehen, durch die  eine Weiterbearbeitung des Materials erlaubt wird.<br/> 
-          Im Unterschied zu den klassischen Lehrmaterialien (siehe rechts) werden OER in erster Linie anderen interessierten Lehrenden zur Nachnutzung zur Verfügung gestellt.</i:de>
-          </p> 
-          <p><i:de>Wenn Sie Ihre digitalen Lehrmaterialien als OER veröffentlichen möchten, beraten wir Sie gern dazu!</i:de>
-          
-        </p>
-       
-        <p>
-         <i:de>Bitte wenden Sie sich hierzu an unsere Ansprechpartnerinnen:</i:de>
-        </p>
-        <p>
-          <a href="mailto:duepublico.ub@uni-due.de">Sonja Hendriks</a>
-          (0203 / 37-92027)
-          <br />
-          <a href="mailto:duepublico.ub@uni-due.de">Katrin Falkenstein-Feldhoff</a>
-          (0203 / 37-91504)
-           <br />
-            <a href="mailto:anke.petschenka@uni-due.de">Anke Petschenka</a>
-          (0201 / 18-34548) 
-        </p>       
-      </div>
-      <div class="card-footer">
-      <a href="../../servlets/MCRActionMappingServlet/OER/create" class="btn btn-primary">Zum Login und OER-Formular
-        </a>
-    </div>
-    </div>
-    
-    
-    <div class="card card-default">
-      <h3 class="card-header">
-        <i class="fas fa-file-alt mr-2" aria-hidden="true" />
-        Lehrmaterialien für die eigenen Studierenden frei zugänglich veröffentlichen
-      </h3>
-      <div class="card-body">
-       <p><img class="float: none" src="../../images/lehrmaterial.png" style="width:35%" /></p>
-      <p>
-      <i:de>Bei den klassischen Lehr- und Lernmaterialen handelt es sich um solche, welche von Dozierenden  
-            für die eigene Lehre erstellt und (über DuEPublico) frei zugänglich gemacht werden. 
-            Die Vergabe einer Open-Content-Lizenz (z.B. Creative Commons-Lizenz)ist hierbei möglich, aber nicht obligatorisch.<br/>
-            Häufig handelt es sich bei den Materialien um Vorlesungsmitschnitte, Präsentationen oder Übungsblätter. 
-            Zielgruppe sind hier hauptsächlich die eigenen Studierenden. </i:de>
-        </p>
-        <p>
-         <i:de>
-         Wenn Sie Ihre digitalen Lehrmaterialien für Ihre Studierenden frei zugänglich veröffentlichen wollen, 
-         unterstützen wir Sie gern dabei!</i:de></p>
-       <p><i:de>Wenden Sie sich bei Fragen gerne über folgende Email-Adresse an uns:<br/>
-        <a href="mailto:duepublico.ub@uni-due.de">duepublico.ub@uni-due.de</a></i:de>
-        </p>
+
+    <div class="card-deck mt-3 mb-3">
+      <div class="card card-default">
+        <h3 class="card-header">
+          <i class="fas fa-file-alt mr-2" aria-hidden="true" />
+          Lehrmaterial als Open Educational Resource (OER) veröffentlichen
+        </h3>
+        <div class="card-body">
+          <p>
+            <img class="float: none" src="../../images/OER_Grafik.png" />
+          </p>
+          <p>
+            <i:de>
+              Open Educational Resources (OER) sind selbsterstellte Bildungs- bzw. Lehrmaterialien,
+              die unter einer freien Lizenz (i. d. R. Creative Commons-Lizenz) stehen, durch die eine Weiterbearbeitung des
+              Materials erlaubt wird.
+              <br />
+              Im Unterschied zu den klassischen Lehrmaterialien (siehe rechts) werden OER in erster Linie anderen
+              interessierten Lehrenden zur Nachnutzung zur Verfügung gestellt.
+            </i:de>
+          </p>
+          <p>
+            <i:de>Wenn Sie Ihre digitalen Lehrmaterialien als OER veröffentlichen möchten, beraten wir Sie gern dazu!</i:de>
+          </p>
+          <p>
+            <i:de>Bitte wenden Sie sich hierzu an unsere Ansprechpartnerinnen:</i:de>
+          </p>
+          <p>
+            <a href="mailto:duepublico.ub@uni-due.de">Sonja Hendriks</a> (0203 / 37-92027) <br />
+            <a href="mailto:duepublico.ub@uni-due.de">Katrin Falkenstein-Feldhoff</a> (0203 / 37-91504) <br />
+            <a href="mailto:anke.petschenka@uni-due.de">Anke Petschenka</a> (0201 / 18-34548)
+          </p>
         </div>
-         <div class="card-footer">
-      <a href="../../servlets/MCRActionMappingServlet/LuL/create" class="btn btn-primary">Zum Login und Lehrmaterial-Formular
-        </a>
-    </div>      
+        <div class="card-footer">
+          <a href="../../servlets/MCRActionMappingServlet/OER/create" class="btn btn-primary">Zum Login und OER-Formular</a>
+        </div>
       </div>
-     </div>
-     
-    
-    
+
+
+      <div class="card card-default">
+        <h3 class="card-header">
+          <i class="fas fa-file-alt mr-2" aria-hidden="true" />
+          Lehrmaterialien für die eigenen Studierenden frei zugänglich veröffentlichen
+        </h3>
+        <div class="card-body">
+          <p>
+            <img class="float: none" src="../../images/lehrmaterial.png" style="width:35%" />
+          </p>
+          <p>
+            <i:de>
+              Bei den klassischen Lehr- und Lernmaterialen handelt es sich um solche, welche von Dozierenden
+              für die eigene Lehre erstellt und (über DuEPublico) frei zugänglich gemacht werden.
+              Die Vergabe einer Open-Content-Lizenz (z.B. Creative Commons-Lizenz)ist hierbei möglich, aber nicht obligatorisch.
+              <br />
+              Häufig handelt es sich bei den Materialien um Vorlesungsmitschnitte, Präsentationen oder Übungsblätter.
+              Zielgruppe sind hier hauptsächlich die eigenen Studierenden.
+            </i:de>
+          </p>
+          <p>
+            <i:de>
+              Wenn Sie Ihre digitalen Lehrmaterialien für Ihre Studierenden frei zugänglich veröffentlichen wollen,
+              unterstützen wir Sie gern dabei!
+            </i:de>
+          </p>
+          <p>
+            <i:de>
+              Wenden Sie sich bei Fragen gerne über folgende Email-Adresse an uns:
+              <br />
+              <a href="mailto:duepublico.ub@uni-due.de">duepublico.ub@uni-due.de</a>
+            </i:de>
+          </p>
+        </div>
+        <div class="card-footer">
+          <a href="../../servlets/MCRActionMappingServlet/LuL/create" class="btn btn-primary">Zum Login und Lehrmaterial-Formular
+          </a>
+        </div>
+      </div>
+    </div>
 
     <div class="card card-default">
       <h3 class="card-header">
-       <i class="fas fa-arrow-alt-circle-right mr-2" aria-hidden="true" />
-         <i:de> Weiterführende Informationen</i:de>
+        <i class="fas fa-arrow-alt-circle-right mr-2" aria-hidden="true" />
+        <i:de> Weiterführende Informationen</i:de>
       </h3>
       <div class="card-body">
-      <p>
-       <i:de>Weitere Informationen zu Open Educational Ressources an der UDE finden Sie auf den
-       <a href="https://www.uni-due.de/ub/publikationsdienste/oer">Webseiten der UB</a>!</i:de>
-      <!--> <i:en>Further information about Open Educational Resources at the UDE can be found on the <a href="https://www.uni-due.de/ub/publikationsdienste/oer">web pages of the<br/> University Library</a>!</i:en> <!-->
-       </p>
-        <p>Weitere Informationen zu Creative Commons-Lizenzen (CC-Lizenzen) finden Sie unter <br/> <a href="https://www.uni-due.de/ub/publikationsdienste/cc_lizenzen.php">https://www.uni-due.de/ub/publikationsdienste/cc_lizenzen.php</a>.</p>
-        <p>Wenn Sie zugriffsgeschütztes Lehrmaterial anlegen möchten, finden Sie auf folgender Seite das richtige Tool für sich:<br/> <a href="https://www.uni-due.de/e-learning/lernmaterialien">https://www.uni-due.de/e-learning/lernmaterialien</a> </p>
+        <p>
+          <i:de>
+            Weitere Informationen zu Open Educational Ressources an der UDE finden Sie auf den
+            <a href="https://www.uni-due.de/ub/publikationsdienste/oer">Webseiten der UB</a>!
+          </i:de>
+        </p>
+        <p>
+          Weitere Informationen zu Creative Commons-Lizenzen (CC-Lizenzen) finden Sie unter
+          <br />
+          <a href="https://www.uni-due.de/ub/publikationsdienste/cc_lizenzen.php">https://www.uni-due.de/ub/publikationsdienste/cc_lizenzen.php</a>.
+        </p>
+        <p>
+          Wenn Sie zugriffsgeschütztes Lehrmaterial anlegen möchten, finden Sie auf folgender Seite das richtige Tool:
+          <br />
+          <a href="https://www.uni-due.de/e-learning/lernmaterialien">https://www.uni-due.de/e-learning/lernmaterialien</a>
+        </p>
+      </div>
     </div>
-   </div>
 
   </section>
 

--- a/src/main/webapp/content/lehrmaterial/publish.xml
+++ b/src/main/webapp/content/lehrmaterial/publish.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<MyCoReWebPage xmlns:i="http://www.mycore.org/i18n">
+
+  <section xml:lang="all" title="DuEPublico: Lehrmaterialien">
+
+    <h2 class="text-center mt-2 mb-3">
+      <i class="fas fa-chalkboard-teacher mr-2" aria-hidden="true" />
+      <i:de>Sie möchten Ihre Lehrmaterialien veröffentlichen? - Wir helfen Ihnen!</i:de>
+    </h2>
+    
+<div class="card-deck mt-3 mb-3">
+    <div class="card card-default">
+      <h3 class="card-header">
+        <i class="fas fa-file-alt mr-2" aria-hidden="true" />
+       Lehrmaterial als Open Educational Resource (OER) veröffentlichen
+      </h3>
+      <div class="card-body">
+       <p><img class="float: none" src="../../images/OER_Grafik.png" /></p>
+        <p>
+          <i:de>
+          Open Educational Resources (OER) sind selbsterstellte Bildungs- bzw. Lehrmaterialien, 
+          die unter einer freien Lizenz (i. d. R. Creative Commons-Lizenz) stehen, durch die  eine Weiterbearbeitung des Materials erlaubt wird.<br/> 
+          Im Unterschied zu den klassischen Lehrmaterialien (siehe rechts) werden OER in erster Linie anderen interessierten Lehrenden zur Nachnutzung zur Verfügung gestellt.</i:de>
+          </p> 
+          <p><i:de>Wenn Sie Ihre digitalen Lehrmaterialien als OER veröffentlichen möchten, beraten wir Sie gern dazu!</i:de>
+          
+        </p>
+       
+        <p>
+         <i:de>Bitte wenden Sie sich hierzu an unsere Ansprechpartnerinnen:</i:de>
+        </p>
+        <p>
+          <a href="mailto:duepublico.ub@uni-due.de">Sonja Hendriks</a>
+          (0203 / 37-92027)
+          <br />
+          <a href="mailto:duepublico.ub@uni-due.de">Katrin Falkenstein-Feldhoff</a>
+          (0203 / 37-91504)
+           <br />
+            <a href="mailto:anke.petschenka@uni-due.de">Anke Petschenka</a>
+          (0201 / 18-34548) 
+        </p>       
+      </div>
+      <div class="card-footer">
+      <a href="../../servlets/MCRActionMappingServlet/OER/create" class="btn btn-primary">Zum Login und OER-Formular
+        </a>
+    </div>
+    </div>
+    
+    
+    <div class="card card-default">
+      <h3 class="card-header">
+        <i class="fas fa-file-alt mr-2" aria-hidden="true" />
+        Lehrmaterialien für die eigenen Studierenden frei zugänglich veröffentlichen
+      </h3>
+      <div class="card-body">
+       <p><img class="float: none" src="../../images/lehrmaterial.png" style="width:35%" /></p>
+      <p>
+      <i:de>Bei den klassischen Lehr- und Lernmaterialen handelt es sich um solche, welche von Dozierenden  
+            für die eigene Lehre erstellt und (über DuEPublico) frei zugänglich gemacht werden. 
+            Die Vergabe einer Open-Content-Lizenz (z.B. Creative Commons-Lizenz)ist hierbei möglich, aber nicht obligatorisch.<br/>
+            Häufig handelt es sich bei den Materialien um Vorlesungsmitschnitte, Präsentationen oder Übungsblätter. 
+            Zielgruppe sind hier hauptsächlich die eigenen Studierenden. </i:de>
+        </p>
+        <p>
+         <i:de>
+         Wenn Sie Ihre digitalen Lehrmaterialien für Ihre Studierenden frei zugänglich veröffentlichen wollen, 
+         unterstützen wir Sie gern dabei!</i:de></p>
+       <p><i:de>Wenden Sie sich bei Fragen gerne über folgende Email-Adresse an uns:<br/>
+        <a href="mailto:duepublico.ub@uni-due.de">duepublico.ub@uni-due.de</a></i:de>
+        </p>
+        </div>
+         <div class="card-footer">
+      <a href="../../servlets/MCRActionMappingServlet/LuL/create" class="btn btn-primary">Zum Login und Lehrmaterial-Formular
+        </a>
+    </div>      
+      </div>
+     </div>
+     
+    
+    
+
+    <div class="card card-default">
+      <h3 class="card-header">
+       <i class="fas fa-arrow-alt-circle-right mr-2" aria-hidden="true" />
+         <i:de> Weiterführende Informationen</i:de>
+      </h3>
+      <div class="card-body">
+      <p>
+       <i:de>Weitere Informationen zu Open Educational Ressources an der UDE finden Sie auf den
+       <a href="https://www.uni-due.de/ub/publikationsdienste/oer">Webseiten der UB</a>!</i:de>
+      <!--> <i:en>Further information about Open Educational Resources at the UDE can be found on the <a href="https://www.uni-due.de/ub/publikationsdienste/oer">web pages of the<br/> University Library</a>!</i:en> <!-->
+       </p>
+        <p>Weitere Informationen zu Creative Commons-Lizenzen (CC-Lizenzen) finden Sie unter <br/> <a href="https://www.uni-due.de/ub/publikationsdienste/cc_lizenzen.php">https://www.uni-due.de/ub/publikationsdienste/cc_lizenzen.php</a>.</p>
+        <p>Wenn Sie zugriffsgeschütztes Lehrmaterial anlegen möchten, finden Sie auf folgender Seite das richtige Tool für sich:<br/> <a href="https://www.uni-due.de/e-learning/lernmaterialien">https://www.uni-due.de/e-learning/lernmaterialien</a> </p>
+    </div>
+   </div>
+
+  </section>
+
+</MyCoReWebPage>


### PR DESCRIPTION
Die neugestaltet Seite zu OER und anderen Lehrmaterialien soll ins Produktivsystem übernommen werden.
Das Eingabeformular für Lehrmaterialien wurde im Vergleich zu dem für OER hinsichtlich des Hinweises zur Lizenzauswahl ebenfalls angepasst.
Links zu dem Eingabeformular für Lehrmaterialien wurden in der actionmappings.xml ergänzt. 