### PR TITLE
Label changed in line 35

### DIFF
--- a/src/main/resources/xsl/series-panel.xsl
+++ b/src/main/resources/xsl/series-panel.xsl
@@ -32,7 +32,7 @@
     <div id="series-layout">
   
       <a href="{$WebApplicationBaseURL}receive/{$rootID}">
-        <img class="card-img-top" src="{$WebApplicationBaseURL}{@banner}" alt="Logo {../label[lang($CurrentLang)]}" />
+        <img class="card-img-top" src="{$WebApplicationBaseURL}{@banner}" alt="Zur Startseite {../label[lang($CurrentLang)]}" />
       </a>
 
       <div class="card">


### PR DESCRIPTION
Wenn (noch) kein passendes Logo für eine Reihennavigation gefunden wurde, steht momentan an der Stelle des Banners "Logo". Das soll ersetzt werden durch "Zur Startseite".