### PR TITLE
E-mail address in line 110 changed

### DIFF
--- a/src/main/webapp/content/brand/contact.xml
+++ b/src/main/webapp/content/brand/contact.xml
@@ -107,7 +107,7 @@
                 <li>
                  Sabrina Wille
                   <br />
-                  <a href="mailto:fbmed.ub@uni-due.org">fbmed.ub@uni-due.org</a>
+                  <a href="mailto:fachbib.med@ub.uni-due.de">fachbib.med@ub.uni-due.de</a>
                   <br />
                   Tel.: 0201 / 723 - 3332
                   <br />


### PR DESCRIPTION
An einer Stelle (Zeile 110) ist noch die E-Mail-Adresse [fbmed.ub@uni-due.org](mailto:fbmed.ub@uni-due.org) angegeben. Diese muss auch wieder durch [fachbib.med@ub.uni-due.de](mailto:fachbib.med@ub.uni-due.de) ersetzt werden.