### PR TITLE
spelling corrected HANDLE -> handle

### DIFF
--- a/src/main/resources/xsl/mods2xMetaDissPlus.xsl
+++ b/src/main/resources/xsl/mods2xMetaDissPlus.xsl
@@ -795,7 +795,7 @@
       <ddb:identifier ddb:type="DOI">
         <xsl:attribute name="ddb:type">
           <xsl:choose>
-            <xsl:when test="@type='hdl'">HANDLE</xsl:when>
+            <xsl:when test="@type='hdl'">handle</xsl:when>
             <xsl:otherwise>
               <xsl:value-of select="translate(@type,'abcdefghijklmnopqrstuvwxyz','ABCDEFGHIJKLMNOPQRSTUVWXYZ')" />
             </xsl:otherwise>


### PR DESCRIPTION
Bezug: "Bei oai:duepublico2.uni-due.de:duepublico_mods_00043645
ist Der Wert ‚HANDLE‘ ist im Element <ddb:identifier ddb:type="HANDLE" >2128/14200</ddb:identifier>
nicht korrekt:
Richtig <ddb:identifier ddb:type="handle"> - bitte ändern"

