### PR TITLE
Redmine 64208: Bidirectional display of "otherVersion" reference

### DIFF
--- a/duepublico-webapp/src/main/resources/xsl/metadata/mir-abstract.xsl
+++ b/duepublico-webapp/src/main/resources/xsl/metadata/mir-abstract.xsl
@@ -275,6 +275,11 @@
         <xsl:with-param name="label" select="i18n:translate('mir.metadata.review')"/>
       </xsl:call-template>
 
+      <xsl:call-template name="findRelatedItems">
+        <xsl:with-param name="query" select="concat('mods.relatedItem.otherVersion:', $objectID, ' AND (', $state, ')')"/>
+        <xsl:with-param name="label" select="i18n:translate('mir.metadata.otherVersion')"/>
+      </xsl:call-template>
+
     </div><!-- end: authors, description, children -->
 
     <xsl:apply-imports />


### PR DESCRIPTION
tested locally, display looks like attachment in Redmine ticket.