### PR TITLE
Add s3 as a derivate type category

### DIFF
--- a/duepublico-setup/src/main/setup/classifications/derivate_types.xml
+++ b/duepublico-setup/src/main/setup/classifications/derivate_types.xml
@@ -24,5 +24,9 @@
       <label xml:lang="de" text="Inhaltsverzeichnis" />
       <label xml:lang="en" text="Table of Contents" />
     </category>
+    <category ID="external_store_s3">
+      <label xml:lang="de" text="S3 Bucket" />
+      <label xml:lang="en" text="S3 Bucket" />
+    </category>
   </categories>
 </mycoreclass>


### PR DESCRIPTION
Already configured as category on duep2 und duep2-dev. Should be added to source code.