### PR TITLE
Activate, brand and style DFG-Viewer hyperlink

### DIFF
--- a/duepublico-extras/src/main/resources/META-INF/resources/css/duepublico.css
+++ b/duepublico-extras/src/main/resources/META-INF/resources/css/duepublico.css
@@ -94,3 +94,13 @@ li.mir-toc-section {
 .shariff .theme-white .bluesky a {
   color: #0085FF;
 }
+
+/* ---------- adapt dfg viewer ---------- */
+#mir-dfgViewer {
+	margin-left: 15px;
+}
+
+/* ---------- dfg viewer hack for missing space before logo ---------- */
+#mir-dfgViewer a img {
+	margin-left: 6px;
+}

--- a/duepublico-webapp/src/main/resources/mycore.properties
+++ b/duepublico-webapp/src/main/resources/mycore.properties
@@ -580,3 +580,12 @@ MCR.MODS.EnrichmentResolver.DataSources.import=PubMed CrossRef ZDB JOP
 ######################################################################
 
 MCR.Filter.UserAgent.BotPattern=(bot|spider|crawler|resolver|mercator|slurp|seek|nagios|java|curl|wget|fetch|googleother|facebookexternalhit|unpaywall|turnitin|sleuth|feedbin|python|uptime-kuma|spotify|podimo|antennapod|tentacles|itms|podbean|podcast|mechanize)
+
+######################################################################
+##                DFG-Viewer                                        ##
+######################################################################
+
+MIR.DFGViewer.enable=true
+MIR.DFGViewer.DV.Owner=Universit\u00E4t Duisburg-Essen
+MIR.DFGViewer.DV.OwnerLogo=https://duepublico2.uni-due.de/images/UDE-logo-claim.svg
+MIR.DFGViewer.DV.OwnerSiteURL=https://duepublico2.uni-due.de


### PR DESCRIPTION
Tested locally (DFG-Viewer page only works with prod Duepublico). Additions to mycore.properties already manually added and tested in prod. Manually added config needs to be deleted upon reinstallation.